### PR TITLE
Add key to <img />

### DIFF
--- a/site/examples/ObjectDataExample.js
+++ b/site/examples/ObjectDataExample.js
@@ -8,7 +8,15 @@ var Table = FixedDataTable.Table;
 var Column = FixedDataTable.Column;
 
 function renderImage(/*string*/ cellData) {
-  return <img src={cellData} width={50} height={50} className="exampleImage" />;
+  return (
+    <img 
+      src={cellData} 
+      key={cellData} 
+      width={50} 
+      height={50} 
+      className="exampleImage" 
+    />
+  );
 }
 
 function renderLink(/*string*/ cellData) {


### PR DESCRIPTION
React recycles the image tags, but when switching the src Chrome (and possibly other browsers?) will keep the old pixels visible until the new resource is loaded and rendered. This means you get a weird inconsistency as the images load in.