### PR TITLE
Don't scroll HeroTable when scrollTop goes < 0

### DIFF
--- a/site/home/Header.js
+++ b/site/home/Header.js
@@ -48,7 +48,7 @@ var Header = React.createClass({
   handleScroll(event) {
     var scrollPos = window.scrollY;
     scrollPos = scrollPos < this.offsetHeight ? scrollPos : this.offsetHeight;
-    this.setState({ scroll: scrollPos });
+    this.setState({ scroll: Math.max(scrollPos, 0) });
   },
 
   _getWindowWidth() {


### PR DESCRIPTION
Chrome/OS X lets you scroll into negative pixels and the table stretches weirdly. I haven't tested this works.