### PR TITLE
Add use strict to all files that also use ES6 classes

### DIFF
--- a/src/vendor_upstream/dom/DOMMouseMoveTracker.js
+++ b/src/vendor_upstream/dom/DOMMouseMoveTracker.js
@@ -10,6 +10,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var EventListener = require('EventListener');
 
 var cancelAnimationFramePolyfill = require('cancelAnimationFramePolyfill');

--- a/src/vendor_upstream/dom/ReactWheelHandler.js
+++ b/src/vendor_upstream/dom/ReactWheelHandler.js
@@ -10,6 +10,8 @@
  * @typechecks
  */
 
+"use strict";
+
 var normalizeWheel = require('normalizeWheel');
 var requestAnimationFramePolyfill = require('requestAnimationFramePolyfill');
 

--- a/src/vendor_upstream/struct/Heap.js
+++ b/src/vendor_upstream/struct/Heap.js
@@ -10,6 +10,7 @@
  * @typechecks
  * @preventMunge
  */
+
 "use strict";
 
 /*

--- a/src/vendor_upstream/struct/IntegerBufferSet.js
+++ b/src/vendor_upstream/struct/IntegerBufferSet.js
@@ -9,7 +9,8 @@
  * @providesModule IntegerBufferSet
  * @typechecks
  */
-'use strict';
+
+"use strict";
 
 var Heap = require('Heap');
 

--- a/src/vendor_upstream/struct/PrefixIntervalTree.js
+++ b/src/vendor_upstream/struct/PrefixIntervalTree.js
@@ -9,6 +9,7 @@
  * @providesModule PrefixIntervalTree
  * @typechecks
  */
+
 "use strict";
 
 /**


### PR DESCRIPTION
With react-tools ES6 class transform if `"use strict";` is not defined at the top of the file it will insert it within each method, this causes a weird bug in Chrome when the file is `eval`ed which is common with webpack for source maps support.

I have added "use strict"; to all files that were also using ES6 classes and taken the chance to standardize some of the `"use strict";` calls.

Solves issue: #20, #35

cc @jbonta, @wlis 