### PR TITLE
Added passing width to groupHeaders and fixed some props of it

### DIFF
--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -842,6 +842,8 @@ var FixedDataTable = React.createClass({
         {
           dataKey: i,
           children: undefined,
+          columnData: columnGroups[i].props.columnGroupData,
+          isHeaderCell: true,
         }
       );
     }

--- a/src/FixedDataTableCell.react.js
+++ b/src/FixedDataTableCell.react.js
@@ -149,7 +149,8 @@ var FixedDataTableCell = React.createClass({
         props.cellData,
         props.cellDataKey,
         props.columnData,
-        props.rowData
+        props.rowData,
+        props.width
       );
     } else {
       content = props.cellRenderer(

--- a/src/FixedDataTableColumn.react.js
+++ b/src/FixedDataTableColumn.react.js
@@ -71,8 +71,9 @@ var FixedDataTableColumn = React.createClass({
      * `function(
      *   any_cellData,
      *   string_cellDataKey,
+     *   any_columnData,
      *   object_rowData,
-     *   any_columnData
+     *   number_width
      *)`
      * that returns React-renderable content for table column header.
      */

--- a/src/FixedDataTableColumnGroup.react.js
+++ b/src/FixedDataTableColumnGroup.react.js
@@ -34,10 +34,16 @@ var FixedDataTableColumnGroup = React.createClass({
     fixed: PropTypes.bool.isRequired,
 
     /**
-     * The function that takes a label and column group data as params and
-     * returns React-renderable content for table header. If this is not set
-     * the label will be the only thing rendered in the column group header
-     * cell.
+     * If not specified, props.label will be rendered into group header.
+     * The group header cell renderer
+     * `function(
+     *   any_label,
+     *   string_cellDataKey,
+     *   any_columnGroupData,
+     *   object_rowData(array of labels of all coludmnGroups),
+     *   number_width
+     *)`
+     * that returns React-renderable content for table column group header.
      */
     groupHeaderRenderer: PropTypes.func,
 


### PR DESCRIPTION
This adds passing width to header, groupHeader and footer cells and fixes description for rendereres, where order of arguments passed by the table was different than specified
In the FixedDataTableCell we have:

    if (props.isHeaderCell || props.isFooterCell) {
       content = props.cellRenderer(
         props.cellData,
         props.cellDataKey,
         props.columnData,
         props.rowData,
         props.width
       );
     } else{...

Also added passing columnGroupData from ColumnGroup props to renderers.
