### PR TITLE
Added passing width to groupHeaders and fixed some props of it

### DIFF
--- a/docs/ColumnAPI.md
+++ b/docs/ColumnAPI.md
@@ -23,16 +23,17 @@ type: `string`
 
 ### `cellRenderer`
 
-The data cell renderer
-`function(
-  any_cellData,
-  string_cellDataKey,
-  object_rowData,
-  number_rowIndex,
-  any_columnData,
-  number_width
-)`
-that returns React-renderable content for table cell.
+The cell renderer that returns React-renderable content for table cell.
+```
+function(
+  cellData: any,
+  cellDataKey: string,
+  rowData: object,
+  rowIndex: number,
+  columnData: any,
+  width: number
+): ?$jsx
+```
 
 type: `func`
 
@@ -59,28 +60,34 @@ type: `union(string|number)`
 
 ### `headerRenderer`
 
-The header cell renderer
-`function(
-  any_cellData,
-  string_cellDataKey,
-  object_rowData,
-  any_columnData
-)`
-that returns React-renderable content for table column header.
+The cell renderer that returns React-renderable content for table column
+header.
+```
+function(
+  label: ?string,
+  cellDataKey: string,
+  columnData: any,
+  rowData: array<?object>,
+  width: number
+): ?$jsx
+```
 
 type: `func`
 
 
 ### `footerRenderer`
 
-The footer cell renderer
-`function(
-  any_cellData,
-  string_cellDataKey,
-  object_rowData,
-  any_columnData
-)`
-that returns React-renderable content for table column footer.
+The cell renderer that returns React-renderable content for table column
+footer.
+```
+function(
+  label: ?string,
+  cellDataKey: string,
+  columnData: any,
+  rowData: array<?object>,
+  width: number
+): ?$jsx
+```
 
 type: `func`
 

--- a/docs/ColumnGroupAPI.md
+++ b/docs/ColumnGroupAPI.md
@@ -21,16 +21,6 @@ Whether the column group is fixed.
 type: `bool`
 
 
-### `groupHeaderRenderer`
-
-The function that takes a label and column group data as params and
-returns React-renderable content for table header. If this is not set
-the label will be the only thing rendered in the column group header
-cell.
-
-type: `func`
-
-
 ### `columnGroupData`
 
 Bucket for any data to be passed into column group renderer functions.
@@ -40,7 +30,25 @@ type: `object`
 
 ### `label`
 
-The column's header label.
+The column group's header label.
 
 type: `string`
+
+
+### `groupHeaderRenderer`
+
+The cell renderer that returns React-renderable content for a table
+column group header. If it's not specified, the label from props will
+be rendered as header content.
+```
+function(
+  label: ?string,
+  cellDataKey: string,
+  columnGroupData: any,
+  rowData: array<?object>, // array of labels of all coludmnGroups
+  width: number
+): ?$jsx
+```
+
+type: `func`
 

--- a/docs/TableAPI.md
+++ b/docs/TableAPI.md
@@ -242,7 +242,7 @@ type: `func`
 
 ### `onRowMouseEnter`
 
-Callback that is called when the mouse eneters a row.
+Callback that is called when the mouse enters a row.
 
 type: `func`
 

--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -234,7 +234,7 @@ var FixedDataTable = React.createClass({
     onRowMouseDown: PropTypes.func,
 
     /**
-     * Callback that is called when the mouse eneters a row.
+     * Callback that is called when the mouse enters a row.
      */
     onRowMouseEnter: PropTypes.func,
 
@@ -842,6 +842,8 @@ var FixedDataTable = React.createClass({
         {
           dataKey: i,
           children: undefined,
+          columnData: columnGroups[i].props.columnGroupData,
+          isHeaderCell: true,
         }
       );
     }

--- a/src/FixedDataTableCell.react.js
+++ b/src/FixedDataTableCell.react.js
@@ -149,7 +149,8 @@ var FixedDataTableCell = React.createClass({
         props.cellData,
         props.cellDataKey,
         props.columnData,
-        props.rowData
+        props.rowData,
+        props.width
       );
     } else {
       content = props.cellRenderer(

--- a/src/FixedDataTableColumn.react.js
+++ b/src/FixedDataTableColumn.react.js
@@ -34,16 +34,17 @@ var FixedDataTableColumn = React.createClass({
     cellClassName: PropTypes.string,
 
     /**
-     * The data cell renderer
-     * `function(
-     *   any_cellData,
-     *   string_cellDataKey,
-     *   object_rowData,
-     *   number_rowIndex,
-     *   any_columnData,
-     *   number_width
-     *)`
-     * that returns React-renderable content for table cell.
+     * The cell renderer that returns React-renderable content for table cell.
+     * ```
+     * function(
+     *   cellData: any,
+     *   cellDataKey: string,
+     *   rowData: object,
+     *   rowIndex: number,
+     *   columnData: any,
+     *   width: number
+     * ): ?$jsx
+     * ```
      */
     cellRenderer: PropTypes.func,
 
@@ -67,26 +68,32 @@ var FixedDataTableColumn = React.createClass({
     ]).isRequired,
 
     /**
-     * The header cell renderer
-     * `function(
-     *   any_cellData,
-     *   string_cellDataKey,
-     *   object_rowData,
-     *   any_columnData
-     *)`
-     * that returns React-renderable content for table column header.
+     * The cell renderer that returns React-renderable content for table column
+     * header.
+     * ```
+     * function(
+     *   label: ?string,
+     *   cellDataKey: string,
+     *   columnData: any,
+     *   rowData: array<?object>,
+     *   width: number
+     * ): ?$jsx
+     * ```
      */
     headerRenderer: PropTypes.func,
 
     /**
-     * The footer cell renderer
-     * `function(
-     *   any_cellData,
-     *   string_cellDataKey,
-     *   object_rowData,
-     *   any_columnData
-     *)`
-     * that returns React-renderable content for table column footer.
+     * The cell renderer that returns React-renderable content for table column
+     * footer.
+     * ```
+     * function(
+     *   label: ?string,
+     *   cellDataKey: string,
+     *   columnData: any,
+     *   rowData: array<?object>,
+     *   width: number
+     * ): ?$jsx
+     * ```
      */
     footerRenderer: PropTypes.func,
 

--- a/src/FixedDataTableColumnGroup.react.js
+++ b/src/FixedDataTableColumnGroup.react.js
@@ -34,22 +34,30 @@ var FixedDataTableColumnGroup = React.createClass({
     fixed: PropTypes.bool.isRequired,
 
     /**
-     * The function that takes a label and column group data as params and
-     * returns React-renderable content for table header. If this is not set
-     * the label will be the only thing rendered in the column group header
-     * cell.
-     */
-    groupHeaderRenderer: PropTypes.func,
-
-    /**
      * Bucket for any data to be passed into column group renderer functions.
      */
     columnGroupData: PropTypes.object,
 
     /**
-     * The column's header label.
+     * The column group's header label.
      */
     label: PropTypes.string,
+
+    /**
+     * The cell renderer that returns React-renderable content for a table
+     * column group header. If it's not specified, the label from props will
+     * be rendered as header content.
+     * ```
+     * function(
+     *   label: ?string,
+     *   cellDataKey: string,
+     *   columnGroupData: any,
+     *   rowData: array<?object>, // array of labels of all coludmnGroups
+     *   width: number
+     * ): ?$jsx
+     * ```
+     */
+    groupHeaderRenderer: PropTypes.func,
   },
 
   render() {


### PR DESCRIPTION
This adds passing width to header, groupHeader and footer cells and fixes description for rendereres, where order of arguments passed by the table was different than specified
In the FixedDataTableCell we have:

    if (props.isHeaderCell || props.isFooterCell) {
       content = props.cellRenderer(
         props.cellData,
         props.cellDataKey,
         props.columnData,
         props.rowData,
         props.width
       );
     } else{...

Also added passing columnGroupData from ColumnGroup props to renderers.