### PR TITLE
Fixed column parameter is no longer undocumented

### DIFF
--- a/docs/ColumnAPI.md
+++ b/docs/ColumnAPI.md
@@ -105,6 +105,12 @@ The column's header label.
 
 type: `string`
 
+### `fixed`
+
+Controls if the column is fixed (false by default) when scrolling in the X axis.
+
+type: `bool`
+
 
 ### `width` (required)
 


### PR DESCRIPTION
It is now undocumented, which made me think that it's impossible to make columns fixed in the X axis.