### PR TITLE
fix: ReadyPool src key initialization need to be set

### DIFF
--- a/site/examples/ExampleImage.js
+++ b/site/examples/ExampleImage.js
@@ -71,6 +71,7 @@ var ExampleImage = React.createClass({
   },
 
   _onLoad(/*string*/ src) {
+    ReadyPool[src] = true;
     if (this.isMounted() && src === this.props.src) {
       this.setState({
         src: src,


### PR DESCRIPTION
For now ReadyPool map is defined but not used.
There are two ways, to delete ReadyPull or to set `ReadyPool[src]` on image load