### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/TableAPI.md
+++ b/docs/TableAPI.md
@@ -52,7 +52,7 @@ Props
 
 ### `width` (required)
 
-Pixel width of table. If all rows do not fit,
+Pixel width of table. If all columns do not fit,
 a horizontal scrollbar will appear.
 
 type: `number`


### PR DESCRIPTION
I'm pretty sure this should be "If all columns do not fit"