### PR TITLE
Fix IE9 issue when creating new array filled with 0

### DIFF
--- a/src/vendor_upstream/struct/PrefixIntervalTree.js
+++ b/src/vendor_upstream/struct/PrefixIntervalTree.js
@@ -28,7 +28,7 @@ class PrefixIntervalTree {
     this._leafCount = leafCount;
     this._internalLeafCount = internalLeafCount;
     var nodeCount = 2 * internalLeafCount;
-    var Int32Array = global.Int32Array || Array;
+    var Int32Array = global.Int32Array || this._initArray;
     this._value = new Int32Array(nodeCount);
     this._initTables(initialLeafValue || 0);
 
@@ -44,6 +44,10 @@ class PrefixIntervalTree {
       internalLeafCount *= 2;
     }
     return internalLeafCount;
+  }
+
+  _initArray(/*number*/ size) /*object*/ {
+    return Array.apply(null, new Array(size)).map(Number.prototype.valueOf, 0);
   }
 
   _initTables(/*number*/ initialLeafValue) {

--- a/src/vendor_upstream/struct/PrefixIntervalTree.js
+++ b/src/vendor_upstream/struct/PrefixIntervalTree.js
@@ -46,8 +46,13 @@ class PrefixIntervalTree {
     return internalLeafCount;
   }
 
-  _initArray(/*number*/ size) /*object*/ {
-    return Array.apply(null, new Array(size)).map(Number.prototype.valueOf, 0);
+  _initArray(/*number*/ size) /*array*/ {
+    var arr = [];
+    while (size > 0) {
+      size--;
+      arr[size] = 0;
+    }
+    return arr;
   }
 
   _initTables(/*number*/ initialLeafValue) {


### PR DESCRIPTION
IE9 doesn't have ```Int32Array``` function, so the array creation in PrefixIntervalTree falls back to ```new Array(nodeCount)```. We expect to create an array filled with 0, but doing this with IE9 will create an array filled with ```undefined```. This PR fixes this issue.