### PR TITLE
Add onScrollStart callback

### DIFF
--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -1021,7 +1021,7 @@ var FixedDataTable = React.createClass({
 
   _onWheel(/*number*/ deltaX, /*number*/ deltaY) {
     if (this.isMounted()) {
-      if (!this.state.isScrolling) {
+      if (!this._isScrolling) {
         this._didScrollStart();
       }
       var x = this.state.scrollX;
@@ -1055,7 +1055,7 @@ var FixedDataTable = React.createClass({
 
   _onHorizontalScroll(/*number*/ scrollPos) {
     if (this.isMounted() && scrollPos !== this.state.scrollX) {
-      if (!this.state.isScrolling) {
+      if (!this._isScrolling) {
         this._didScrollStart();
       }
       this.setState({
@@ -1067,7 +1067,7 @@ var FixedDataTable = React.createClass({
 
   _onVerticalScroll(/*number*/ scrollPos) {
     if (this.isMounted() && scrollPos !== this.state.scrollY) {
-      if (!this.state.isScrolling) {
+      if (!this._isScrolling) {
         this._didScrollStart();
       }
       var scrollState = this._scrollHelper.scrollTo(Math.round(scrollPos));
@@ -1082,8 +1082,8 @@ var FixedDataTable = React.createClass({
   },
 
   _didScrollStart() {
-    if (this.isMounted() && !this.state.isScrolling) {
-      this.setState({isScrolling:true});
+    if (this.isMounted() && !this._isScrolling) {
+      this._isScrolling = true;
       if (this.props.onScrollStart) {
         this.props.onScrollStart(this.state.scrollX, this.state.scrollY);
       }
@@ -1091,8 +1091,8 @@ var FixedDataTable = React.createClass({
   },
 
   _didScrollStop() {
-    if (this.isMounted() && this.state.isScrolling) {
-      this.setState({isScrolling:false});
+    if (this.isMounted() && this._isScrolling) {
+      this._isScrolling = false;
       if (this.props.onScrollEnd) {
         this.props.onScrollEnd(this.state.scrollX, this.state.scrollY);
       }

--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -225,6 +225,12 @@ var FixedDataTable = React.createClass({
     scrollToRow: PropTypes.number,
 
     /**
+     * Callback that is called when scrolling starts with current horizontal
+     * and vertical scroll values.
+     */
+    onScrollStart: PropTypes.func,
+
+    /**
      * Callback that is called when scrolling ends or stops with new horizontal
      * and vertical scroll values.
      */
@@ -1015,6 +1021,9 @@ var FixedDataTable = React.createClass({
 
   _onWheel(/*number*/ deltaX, /*number*/ deltaY) {
     if (this.isMounted()) {
+      if (!this.state.isScrolling) {
+        this._didScrollStart();
+      }
       var x = this.state.scrollX;
       if (Math.abs(deltaY) > Math.abs(deltaX) &&
           this.props.overflowY !== 'hidden') {
@@ -1046,6 +1055,9 @@ var FixedDataTable = React.createClass({
 
   _onHorizontalScroll(/*number*/ scrollPos) {
     if (this.isMounted() && scrollPos !== this.state.scrollX) {
+      if (!this.state.isScrolling) {
+        this._didScrollStart();
+      }
       this.setState({
         scrollX: scrollPos,
       });
@@ -1055,6 +1067,9 @@ var FixedDataTable = React.createClass({
 
   _onVerticalScroll(/*number*/ scrollPos) {
     if (this.isMounted() && scrollPos !== this.state.scrollY) {
+      if (!this.state.isScrolling) {
+        this._didScrollStart();
+      }
       var scrollState = this._scrollHelper.scrollTo(Math.round(scrollPos));
       this.setState({
         firstRowIndex: scrollState.index,
@@ -1066,8 +1081,18 @@ var FixedDataTable = React.createClass({
     }
   },
 
+  _didScrollStart() {
+    if (this.isMounted() && !this.state.isScrolling) {
+      this.setState({isScrolling:true});
+      if (this.props.onScrollStart) {
+        this.props.onScrollStart(this.state.scrollX, this.state.scrollY);
+      }
+    }
+  },
+
   _didScrollStop() {
-    if (this.isMounted()) {
+    if (this.isMounted() && this.state.isScrolling) {
+      this.setState({isScrolling:false});
       if (this.props.onScrollEnd) {
         this.props.onScrollEnd(this.state.scrollX, this.state.scrollY);
       }


### PR DESCRIPTION
Adds `onScrollStart` callback to be paired with FixedDataTable's existing `onScrollEnd`.

#### Problem

In order to add a hover state to a row we need to redraw when the mouse enters and leaves each row. This can be done using css hover or using the Table's `onRowMouseEnter` and `onRowMouseLeave`. The problem with both of these options is that when mouse wheel scrolling no native mouse leave event seems to fire from the browser (seen at least in FF, Chrome, Safari). This means as the row scrolls off it remains in hovered state even though the mouse is no longer over it. I believe this is a translate/translate3d bug or optimisation.

![hover-screencap](https://cloud.githubusercontent.com/assets/56844/7786267/40257178-0204-11e5-9fd2-6122d0409cdb.jpg)

Only when you move the mouse again does hover state update. This also means that when you stop wheel scrolling the row under the mouse does not draw its hovered state until you move the mouse.

As mentioned in  #17 css hover is preferred for performance reasons, but even if that did work properly you'd still be sacrificing some performance due to constant redraws during scrolling.

#### Solution

When `onScrollStart` fires remove current hover state and disable hover updates until `onScrollEnd`.

As a side note, in order to reapply the hover state when wheel scrolling stops I track the mouse position while the table is mounted and when `onScrollEnd` fires I do some basic hit detection based on the scroll position to determine which row is under the mouse.

Maybe there's a simpler solution for all this? For now this was the only way I could find to get bug free + performant hover states.
