### PR TITLE
DOMMouseMoveTracker: end mouse move when mouse button is released

### DIFF
--- a/src/vendor_upstream/dom/DOMMouseMoveTracker.js
+++ b/src/vendor_upstream/dom/DOMMouseMoveTracker.js
@@ -107,22 +107,26 @@ class DOMMouseMoveTracker {
    * Calls onMove passed into constructor and updates internal state.
    */
   _onMouseMove(/*object*/ event) {
-    var x = event.clientX;
-    var y = event.clientY;
+    if (event.buttons === 0) {
+      this._onMoveEnd();
+    } else {
+      var x = event.clientX;
+      var y = event.clientY;
 
-    this._deltaX += (x - this._x);
-    this._deltaY += (y - this._y);
+      this._deltaX += (x - this._x);
+      this._deltaY += (y - this._y);
 
-    if (this._animationFrameID === null) {
-      // The mouse may move faster then the animation frame does.
-      // Use `requestAnimationFramePolyfill` to avoid over-updating.
-      this._animationFrameID =
-        requestAnimationFramePolyfill(this._didMouseMove);
+      if (this._animationFrameID === null) {
+        // The mouse may move faster then the animation frame does.
+        // Use `requestAnimationFramePolyfill` to avoid over-updating.
+        this._animationFrameID =
+          requestAnimationFramePolyfill(this._didMouseMove);
+      }
+
+      this._x = x;
+      this._y = y;
+      event.preventDefault();
     }
-
-    this._x = x;
-    this._y = y;
-    event.preventDefault();
   }
 
   _didMouseMove() {


### PR DESCRIPTION
I'm not sure if this is the right way to fix this but...

In Firefox browser when user starts scrolling then moves mouse outside the document, releases the button and then moves back to document the DataTable is stills scrolls after the mouse which looks junky and weird as user already released the mouse button.

This PR just adds a check for `event.buttons` on `mousemove` to see if there are pressed buttons, otherwise it just cancels the `mousemove` and calls `onMouseEnd` callback.