### PR TITLE
Expanding rows like DataTables

### DIFF
--- a/build_helpers/startSiteDevServer.sh
+++ b/build_helpers/startSiteDevServer.sh
@@ -7,4 +7,4 @@ rm -rf ./__site_prerender__
 ./build_helpers/buildAPIDocs.sh
 webpack --config "$PWD/site/webpack-prerender.config.js"
 ./build_helpers/buildSiteIndexPages.sh
-webpack-dev-server --config "$PWD/site/webpack-client.config.js" --no-info --content-base __site__
+webpack-dev-server --host 0.0.0.0 --config "$PWD/site/webpack-client.config.js" --no-info --content-base __site__

--- a/site/examples/ObjectDataExample.js
+++ b/site/examples/ObjectDataExample.js
@@ -36,6 +36,7 @@ function renderDate(/*object*/ cellData) {
   return <span>{cellData.toLocaleString()}</span>;
 }
 
+
 var ObjectDataExample = React.createClass({
 
   propTypes: {
@@ -51,7 +52,8 @@ var ObjectDataExample = React.createClass({
 
   getInitialState() {
     return {
-      dataList: new FakeObjectDataListStore(ROWS)
+      dataList: new FakeObjectDataListStore(ROWS),
+      expansions: {}
     }
   },
 
@@ -72,6 +74,23 @@ var ObjectDataExample = React.createClass({
         width={this.props.tableWidth}
         height={this.props.tableHeight}
         onContentHeightChange={this._onContentHeightChange}
+        rowExpansionHeightGetter={(idx) => {
+          if(this.state.expansions[idx]) {
+            return 200;
+          }
+          return 0;
+        }}
+        onRowClick={(e, idx) => {
+          var expansions = this.state.expansions;
+          expansions[idx] = !expansions[idx];
+          this.setState({
+            expansions: expansions
+          });
+        }}
+        rowExpansionRenderer={(...args) => {
+          console.log(...args);
+          return null;
+        }}
         scrollTop={this.props.top}
         scrollLeft={this.props.left}
         overflowX={controlledScrolling ? "hidden" : "auto"}

--- a/site/examples/ObjectDataExample.js
+++ b/site/examples/ObjectDataExample.js
@@ -60,6 +60,27 @@ var ObjectDataExample = React.createClass({
   _rowGetter(index){
     return this.state.dataList.getObjectAt(index);
   },
+  _rowExpansionHeightGetter(index) {
+    return this.state.expansions[index] ? 200 : 0;
+  },
+  _rowExpansionRenderer(index, data, width) {
+    var style = {
+      width: width,
+      height: 200,
+      backgroundImage: 'url(' + data.avartar + ')'
+    };
+    return (
+      <div style={style}>
+      </div>
+    );
+  },
+  _handleRowClick(e, index) {
+    var expansions = this.state.expansions;
+    expansions[index] = !expansions[index];
+    this.setState({
+      expansions: expansions
+    });
+  },
 
   render() {
     var controlledScrolling =
@@ -74,23 +95,9 @@ var ObjectDataExample = React.createClass({
         width={this.props.tableWidth}
         height={this.props.tableHeight}
         onContentHeightChange={this._onContentHeightChange}
-        rowExpansionHeightGetter={(idx) => {
-          if(this.state.expansions[idx]) {
-            return 200;
-          }
-          return 0;
-        }}
-        onRowClick={(e, idx) => {
-          var expansions = this.state.expansions;
-          expansions[idx] = !expansions[idx];
-          this.setState({
-            expansions: expansions
-          });
-        }}
-        rowExpansionRenderer={(...args) => {
-          console.log(...args);
-          return null;
-        }}
+        rowExpansionHeightGetter={this._rowExpansionHeightGetter}
+        onRowClick={this._handleRowClick}
+        rowExpansionRenderer={this._rowExpansionRenderer}
         scrollTop={this.props.top}
         scrollLeft={this.props.left}
         overflowX={controlledScrolling ? "hidden" : "auto"}

--- a/site/examples/TouchableArea.js
+++ b/site/examples/TouchableArea.js
@@ -11,6 +11,7 @@
  */
 
 var React = require('React');
+React.initializeTouchEvents();
 
 var TouchableArea = React.createClass({
   getDefaultProps() {

--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -279,6 +279,11 @@ var FixedDataTable = React.createClass({
      * Whether a column is currently being resized.
      */
     isColumnResizing: PropTypes.bool,
+
+
+    rowExpansionRenderer: PropTypes.func,
+
+    rowExpansionHeightGetter: PropTypes.func
   },
 
   getDefaultProps() /*object*/ {
@@ -302,7 +307,8 @@ var FixedDataTable = React.createClass({
       props.rowsCount,
       props.rowHeight,
       viewportHeight,
-      props.rowHeightGetter
+      props.rowHeightGetter,
+      props.rowExpansionHeightGetter
     );
     if (props.scrollTop) {
       this._scrollHelper.scrollTo(props.scrollTop);
@@ -624,6 +630,8 @@ var FixedDataTable = React.createClass({
         rowsCount={state.rowsCount}
         rowGetter={state.rowGetter}
         rowHeightGetter={state.rowHeightGetter}
+        rowExpansionHeightGetter={state.rowExpansionHeightGetter}
+        rowExpansionRenderer={state.rowExpansionRenderer}
         scrollLeft={state.scrollX}
         scrollableColumns={state.bodyScrollableColumns}
         showLastRowBorder={true}
@@ -810,7 +818,8 @@ var FixedDataTable = React.createClass({
         props.rowsCount,
         props.rowHeight,
         viewportHeight,
-        props.rowHeightGetter
+        props.rowHeightGetter,
+        props.rowExpansionHeightGetter
       );
       var scrollState =
         this._scrollHelper.scrollToRow(firstRowIndex, firstRowOffset);

--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -44,6 +44,8 @@ var FixedDataTableBufferedRows = React.createClass({
     scrollableColumns: PropTypes.array.isRequired,
     showLastRowBorder: PropTypes.bool,
     width: PropTypes.number.isRequired,
+    rowExpansionHeightGetter: PropTypes.func,
+    rowExpansionRenderer: PropTypes.func,
   },
 
   getInitialState() /*object*/ {
@@ -124,6 +126,7 @@ var FixedDataTableBufferedRows = React.createClass({
     for (var i = 0; i < rowsToRender.length; ++i) {
       var rowIndex = rowsToRender[i];
       var currentRowHeight = this._getRowHeight(rowIndex);
+      var currentExpansionHeight = this._getRowExpansionHeight(rowIndex);
       var rowOffsetTop = rowPositionGetter(rowIndex);
 
       var hasBottomBorder =
@@ -136,10 +139,12 @@ var FixedDataTableBufferedRows = React.createClass({
           data={rowGetter(rowIndex)}
           width={props.width}
           height={currentRowHeight}
+          expansionHeight={currentExpansionHeight}
           scrollLeft={Math.round(props.scrollLeft)}
           offsetTop={Math.round(rowOffsetTop)}
           fixedColumns={props.fixedColumns}
           scrollableColumns={props.scrollableColumns}
+          expansionRenderer={props.rowExpansionRenderer}
           onClick={props.onRowClick}
           onDoubleClick={props.onRowDoubleClick}
           onMouseDown={props.onRowMouseDown}
@@ -175,6 +180,11 @@ var FixedDataTableBufferedRows = React.createClass({
     return this.props.rowHeightGetter ?
       this.props.rowHeightGetter(index) :
       this.props.defaultRowHeight;
+  },
+  _getRowExpansionHeight(/*number*/ index) /*number*/ {
+    return this.props.rowExpansionHeightGetter ?
+      this.props.rowExpansionHeightGetter(index) :
+      0;
   },
 });
 

--- a/src/FixedDataTableRow.react.js
+++ b/src/FixedDataTableRow.react.js
@@ -251,8 +251,11 @@ var FixedDataTableRowExpansion = React.createClass({
       'fixedDataTableRowLayout/expansion': true,
       'public/fixedDataTableRow/expansion': true,
     });
-    var content = this.props.expansionRenderer(this.props.index,
-                                               this.props.data);
+    var content = this.props.expansionRenderer(
+      this.props.index,
+      this.props.data,
+      this.props.width
+    );
 
     return (
       <div

--- a/src/FixedDataTableRow.react.js
+++ b/src/FixedDataTableRow.react.js
@@ -211,6 +211,60 @@ var FixedDataTableRowImpl = React.createClass({
   },
 });
 
+var FixedDataTableRowExpansion = React.createClass({
+  mixins: [ReactComponentWithPureRenderMixin],
+
+  propTypes: {
+    /**
+     * Height of the row.
+     */
+    height: PropTypes.number.isRequired,
+
+    /**
+     * Height of the expansion content
+     */
+    expansionHeight: PropTypes.number,
+
+    /**
+     * Renderer for the expansion content
+     */
+    expansionRenderer: PropTypes.func,
+
+    /**
+     * The row index.
+     */
+    index: PropTypes.number.isRequired,
+
+    /**
+     * Width of the row.
+     */
+    width: PropTypes.number.isRequired,
+
+  },
+  render() {
+    var style = {
+      width: this.props.width,
+      height: this.props.expansionHeight,
+      top: this.props.height
+    };
+    var className = cx({
+      'fixedDataTableRowLayout/expansion': true,
+      'public/fixedDataTableRow/expansion': true,
+    });
+    var content = this.props.expansionRenderer(this.props.index,
+                                               this.props.data);
+
+    return (
+      <div
+        style={style}
+        className={joinClasses(className, this.props.className)}
+        >
+        {content}
+      </div>
+    );
+  }
+})
+
 var FixedDataTableRow = React.createClass({
   mixins: [ReactComponentWithPureRenderMixin],
 
@@ -220,6 +274,7 @@ var FixedDataTableRow = React.createClass({
      */
     height: PropTypes.number.isRequired,
 
+    expansionHeight: PropTypes.number,
     /**
      * Z-index on which the row will be displayed. Used e.g. for keeping
      * header and footer in front of other rows.
@@ -236,14 +291,25 @@ var FixedDataTableRow = React.createClass({
      */
     width: PropTypes.number.isRequired,
   },
+  defaultProps: {
+    expansionHeight: 0
+  },
 
   render() /*object*/ {
     var style = {
       width: this.props.width,
-      height: this.props.height,
+      height: this.props.height + this.props.expansionHeight,
       zIndex: (this.props.zIndex ? this.props.zIndex : 0),
     };
     translateDOMPositionXY(style, 0, this.props.offsetTop);
+    var expansion;
+    if(this.props.expansionHeight > 0 && this.props.expansionRenderer) {
+      expansion = (
+        <FixedDataTableRowExpansion
+          {...this.props}
+        />
+      );
+    }
 
     return (
       <div
@@ -254,6 +320,7 @@ var FixedDataTableRow = React.createClass({
           offsetTop={undefined}
           zIndex={undefined}
         />
+        {expansion}
       </div>
     );
   },

--- a/src/css/layout/fixedDataTableRowLayout.css
+++ b/src/css/layout/fixedDataTableRowLayout.css
@@ -22,6 +22,12 @@
   top: 0;
 }
 
+.fixedDataTableRowLayout/expansion {
+  overflow: hidden;
+  position: absolute;
+  left: 0;
+}
+
 .fixedDataTableRowLayout/fixedColumnsDivider {
   backface-visibility: hidden;
   border-left-style: solid;


### PR DESCRIPTION
A project that I am working calls for a data table implementation with expandable rows to display extra info. By comparison I prefer fixed-data-table over using DataTables.

So I attempted to add the feature into fixed-data-table.

The change primarily modifies the FixedDataTableScrollHelper to increase the rowOffsetTops by the height of the expanded area, and FixedDataTableRow implementation to keep the appended container within the row.

The buffering logic remains the same without taking account of the expanded heights. Frankly I am not sure how that should be modified.

Performance-wise, this modification doesn't seem to have much effects, but I am not completely certain on that.