### PR TITLE
When faceSize < FACE_SIZE_MIN, scale calculation is off

### DIFF
--- a/src/Scrollbar.react.js
+++ b/src/Scrollbar.react.js
@@ -258,7 +258,7 @@ var Scrollbar = React.createClass({
     var faceSize = size * scale;
 
     if (faceSize < FACE_SIZE_MIN) {
-      scale = (size - FACE_SIZE_MIN) / (contentSize - FACE_SIZE_MIN);
+      scale = (size - FACE_SIZE_MIN) / (contentSize - size);
       faceSize = FACE_SIZE_MIN;
     }
 


### PR DESCRIPTION
maximum top position of the scroll face should be {size - faceSize}.
max scroll position of the table = maxPosition = contentSize - size.
So the scale should be calculated as {(size-faceSize)/(contentSize - size)}, where faceSize = FACE_SIZE_MIN in this case.
