### PR TITLE
Make this module can work with 0.14.0-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A React table component designed to allow presenting thousands of rows of data.",
   "main": "main.js",
   "peerDependencies": {
-    "react": ">=0.13.0 <0.15.0 || 0.14.0-beta3"
+    "react": ">=0.13.0 <0.15.0 || ^0.14.0-beta3"
   },
   "devDependencies": {
     "autoprefixer": "^5.0.0",


### PR DESCRIPTION
fix
npm ERR! peerinvalid The package react@0.14.0-rc1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer fixed-data-table@0.4.6 wants react@>=0.13.0 <0.15.0 || 0.14.0-beta3