### PR TITLE
Pure cell rendering 286

### DIFF
--- a/site/Constants.js
+++ b/site/Constants.js
@@ -51,7 +51,12 @@ exports.ExamplePages = {
   SORT_EXAMPLE: {
     location: 'example-sort.html',
     title: 'Client-side Sort',
-    description: 'A table example that is sortable by column.'
+    description: 'A table example that is sortable by column.',
+  },
+  CHANGE_EXAMPLE: {
+    location: 'example-change.html',
+    title: 'Pure rendering cells',
+    description: 'A table example that shows pure rendering cells: clicking the row of one of the tables changes the value of the first column and paints the rerendered cells in a different background. Table above does not use pureCellRendering and table below does. On the first table the whole row is rerendered and on the one that uses pureCellRendering - only the changed cell.',
   },
 };
 

--- a/site/examples/ChangeExample.js
+++ b/site/examples/ChangeExample.js
@@ -1,0 +1,168 @@
+"use strict";
+
+var ROWS = 1000000;
+
+var FakeObjectDataListStore = require('./FakeObjectDataListStore');
+var FixedDataTable = require('fixed-data-table');
+var React = require('react');
+
+var Column = FixedDataTable.Column;
+var PropTypes = React.PropTypes;
+var Table = FixedDataTable.Table;
+
+var faker = require('faker');
+var ImmutableObject = require('ImmutableObject');
+
+var columnWidths = {
+  firstName: 200,
+  lastName: 200,
+  sentence: 200,
+  companyName: 200,
+};
+
+var ChangeExample = React.createClass({
+  propTypes: {
+    onContentDimensionsChange: PropTypes.func,
+    left: PropTypes.number,
+    top: PropTypes.number,
+  },
+
+  getInitialState() {
+    return {
+      dataList: new FakeObjectDataListStore(ROWS),
+      randomColor: [255, 255, 255],
+    }
+  },
+
+  _cellRenderer(cellData) {
+    var style = {
+      backgroundColor: 'rgb(' + this.state.randomColor[0] + ',' +
+        this.state.randomColor[1] + ',' + this.state.randomColor[2] + ')'
+    };
+
+    return(
+      <div style={style}>
+        {cellData}
+      </div>
+    )
+  },
+
+  _rowGetter(index) {
+    return this.state.dataList.getObjectAt(index);
+  },
+
+  _onRowClick(e, index) {
+    var dataList = this.state.dataList;
+    var obj = dataList.getObjectAt(index);
+    obj = ImmutableObject.setProperty(obj, 'firstName', faker.name.firstName());
+    dataList.setObjectAt(index, obj);
+
+    this.setState({
+      randomColor: [
+        Math.floor(Math.random()*255),
+        Math.floor(Math.random()*255),
+        Math.floor(Math.random()*255)
+      ],
+      dataList: dataList,
+    });
+  },
+
+  render() {
+    var controlledScrolling =
+      this.props.left !== undefined || this.props.top !== undefined;
+
+    return (
+      <div>
+        <Table
+          rowHeight={30}
+          headerHeight={50}
+          rowGetter={this._rowGetter}
+          rowsCount={this.state.dataList.getSize()}
+          width={this.props.tableWidth}
+          height={200}
+          scrollTop={this.props.top}
+          scrollLeft={this.props.left}
+          onRowClick={this._onRowClick}
+          overflowX={controlledScrolling ? "hidden" : "auto"}
+          overflowY={controlledScrolling ? "hidden" : "auto"}
+        >
+          <Column
+            cellRenderer={this._cellRenderer}
+            dataKey="firstName"
+            label="First Name"
+            width={columnWidths['firstName']}
+          />
+          <Column
+            cellRenderer={this._cellRenderer}
+            label="Last Name (min/max constrained)"
+            dataKey="lastName"
+            flexGrow={1}
+            width={columnWidths['lastName']}
+          />
+          <Column
+            cellRenderer={this._cellRenderer}
+            label="Company"
+            dataKey="companyName"
+            flexGrow={1}
+            width={columnWidths['companyName']}
+          />
+          <Column
+            cellRenderer={this._cellRenderer}
+            label="Sentence"
+            dataKey="sentence"
+            flexGrow={1}
+            width={columnWidths['sentence']}
+          />
+        </Table>
+        <hr />
+        <Table
+          rowHeight={30}
+          headerHeight={50}
+          rowGetter={this._rowGetter}
+          rowsCount={this.state.dataList.getSize()}
+          width={this.props.tableWidth}
+          height={200}
+          scrollTop={this.props.top}
+          scrollLeft={this.props.left}
+          onRowClick={this._onRowClick}
+          overflowX={controlledScrolling ? "hidden" : "auto"}
+          overflowY={controlledScrolling ? "hidden" : "auto"}
+        >
+          <Column
+            cellRenderer={this._cellRenderer}
+            dataKey="firstName"
+            label="First Name"
+            width={columnWidths['firstName']}
+            pureCellRendering={true}
+          />
+          <Column
+            cellRenderer={this._cellRenderer}
+            label="Last Name (min/max constrained)"
+            dataKey="lastName"
+            flexGrow={1}
+            width={columnWidths['lastName']}
+            pureCellRendering={true}
+          />
+          <Column
+            cellRenderer={this._cellRenderer}
+            label="Company"
+            dataKey="companyName"
+            flexGrow={1}
+            width={columnWidths['companyName']}
+            pureCellRendering={true}
+          />
+          <Column
+            cellRenderer={this._cellRenderer}
+            label="Sentence"
+            dataKey="sentence"
+            flexGrow={1}
+            width={columnWidths['sentence']}
+            pureCellRendering={true}
+          />
+        </Table>
+      </div>
+    );
+  }
+});
+
+module.exports = ChangeExample;

--- a/site/examples/ExamplesPage.js
+++ b/site/examples/ExamplesPage.js
@@ -94,6 +94,13 @@ var ExamplesPage = React.createClass({
             <SortExample />
           </TouchExampleWrapper>
         );
+      case ExamplePages.CHANGE_EXAMPLE:
+        var SortExample = require('./ChangeExample');
+        return (
+          <TouchExampleWrapper {...this.state}>
+            <SortExample />
+          </TouchExampleWrapper>
+        );
     }
   },
 

--- a/site/examples/FakeObjectDataListStore.js
+++ b/site/examples/FakeObjectDataListStore.js
@@ -11,6 +11,7 @@
  */
 
 var faker = require('faker');
+var ImmutableObject = require('ImmutableObject');
 
 class FakeObjectDataListStore {
   constructor(/*number*/ size){
@@ -42,14 +43,14 @@ class FakeObjectDataListStore {
       return undefined;
     }
     if (this._cache[index] === undefined) {
-      this._cache[index] = this.createFakeRowObjectData(index);
+      this._cache[index] = new ImmutableObject(this.createFakeRowObjectData(index));
     }
     return this._cache[index];
   }
 
   /**
   * Populates the entire cache with data.
-  * Use with Caution! Behaves slowly for large sizes 
+  * Use with Caution! Behaves slowly for large sizes
   * ex. 100,000 rows
   */
   getAll() {
@@ -63,6 +64,13 @@ class FakeObjectDataListStore {
 
   getSize() {
     return this.size;
+  }
+
+  setObjectAt(/*number*/ index, /*?object*/ obj) {
+    if (index < 0 || index > this.size){
+      return;
+    }
+    this._cache[index] = obj;
   }
 }
 

--- a/src/FixedDataTableCellGroup.react.js
+++ b/src/FixedDataTableCellGroup.react.js
@@ -142,6 +142,12 @@ var FixedDataTableCellGroupImpl = React.createClass({
       className = columnProps.cellClassName;
     }
 
+    //don't pass rowData or columnData on pure render
+    if (columnProps.pureCellRendering) {
+      rowData = EMPTY_OBJECT;
+      columnData = EMPTY_OBJECT;
+    }
+
     return (
       <FixedDataTableCell
         align={columnProps.align}

--- a/src/FixedDataTableColumn.react.js
+++ b/src/FixedDataTableColumn.react.js
@@ -168,11 +168,18 @@ var FixedDataTableColumn = React.createClass({
      * cell rendered if the row it belongs to is visible.
      */
       allowCellsRecycling: PropTypes.bool,
+
+      /**
+       * Whether to render cells in this column using cellData only (no rowData
+       * or columnData)
+       */
+      pureCellRendering: PropTypes.bool,
   },
 
   getDefaultProps() /*object*/ {
     return {
       allowCellsRecycling: false,
+      pureCellRendering: false,
       fixed: false,
     };
   },


### PR DESCRIPTION
Fix for #286 

Added `pureCellRendering` property to Column component. When this prop is set to `true` `rowData` and `columnData` are not passed into cell component, thus re-rendering only changed cell and not the entire row.

Working example on: http://anytimecoder.github.io/fixed-data-table/example-change.html (click the row in the example tables)