### PR TITLE
Fixed typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the default stylesheet `dist/fixed-data-table.css`, then import it into any 
 ### Basic Example
 
 ```javascript
-import React from 'react');
+import React from 'react';
 import ReactDOM from 'react-dom';
 import {Table, Column, Cell} from 'fixed-data-table';
 


### PR DESCRIPTION
Even though 100% of the devs will figure it is a typo, I decided to send this very simple PR to fix this:
 
`import React from 'react')`