### PR TITLE
Ignore oldState when dimension props have changed

### DIFF
--- a/src/FixedDataTableNew.react.js
+++ b/src/FixedDataTableNew.react.js
@@ -745,6 +745,14 @@ var FixedDataTable = React.createClass({
       useGroupHeader = true;
     }
 
+    if (oldState && (
+      (props.width !== undefined && props.width !== oldState.width) ||
+      (props.height !== undefined && props.height !== oldState.height) ||
+      (props.maxWidth !== undefined && props.maxWidth !== oldState.maxWidth) ||
+      (props.maxHeight !== undefined && props.maxHeight !== oldState.maxHeight))) {
+      oldState = null
+    }
+
     var firstRowIndex = (oldState && oldState.firstRowIndex) || 0;
     var firstRowOffset = (oldState && oldState.firstRowOffset) || 0;
     var scrollX, scrollY;


### PR DESCRIPTION
See issue here: https://github.com/facebook/fixed-data-table/issues/330

Easiest repro steps would be to set a table's `scrollTop` to a positive value and `width` and `maxHeight` to `0` initially then to some positive value after a small setTimeout. Before this change the internal scroll position would we at `0` but afterwards it would be at the desired scrollTop position. 
