### PR TITLE
Fix little typo avartar -> avatar

### DIFF
--- a/examples/FilterExample.js
+++ b/examples/FilterExample.js
@@ -99,7 +99,7 @@ class FilterExample extends React.Component {
           height={500}
           {...this.props}>
           <Column
-            cell={<ImageCell data={filteredDataList} col="avartar" />}
+            cell={<ImageCell data={filteredDataList} col="avatar" />}
             fixed={true}
             width={50}
           />

--- a/examples/ObjectDataExample.js
+++ b/examples/ObjectDataExample.js
@@ -63,7 +63,7 @@ class ObjectDataExample extends React.Component {
         height={500}
         {...this.props}>
         <Column
-          cell={<ImageCell data={dataList} col="avartar" />}
+          cell={<ImageCell data={dataList} col="avatar" />}
           fixed={true}
           width={50}
         />

--- a/examples/helpers/FakeObjectDataListStore.js
+++ b/examples/helpers/FakeObjectDataListStore.js
@@ -21,7 +21,7 @@ class FakeObjectDataListStore {
   createFakeRowObjectData(/*number*/ index) /*object*/ {
     return {
       id: index,
-      avartar: faker.image.avatar(),
+      avatar: faker.image.avatar(),
       city: faker.address.city(),
       email: faker.internet.email(),
       firstName: faker.name.firstName(),

--- a/examples/old/FilterExample.js
+++ b/examples/old/FilterExample.js
@@ -74,7 +74,7 @@ var FilterExample = React.createClass({
           {...this.props}>
           <Column
             cellRenderer={renderImage}
-            dataKey='avartar'
+            dataKey='avatar'
             fixed={true}
             label=''
             width={50}

--- a/examples/old/ObjectDataExample.js
+++ b/examples/old/ObjectDataExample.js
@@ -58,7 +58,7 @@ var ObjectDataExample = React.createClass({
         {...this.props}>
         <Column
           cellRenderer={renderImage}
-          dataKey="avartar"
+          dataKey="avatar"
           fixed={true}
           label=""
           width={50}


### PR DESCRIPTION
When looking at the examples I spotted a typo for `avatar`

So I updated it across the repo. :pencil2: :bee: :smile: 