### PR TITLE
Prevent deopt in cx.js

### DIFF
--- a/src/vendor_upstream/stubs/cx.js
+++ b/src/vendor_upstream/stubs/cx.js
@@ -43,7 +43,10 @@ function cx(classNames) {
       return classNames[className];
     });
   } else {
-    classNamesArray = Array.prototype.slice.call(arguments);
+    classNamesArray = Array(arguments.length);
+    for (var i = 0; i < arguments.length; i++) {
+      classNamesArray[i] = arguments[i];
+    }
   }
 
   return classNamesArray.map(getClassName).join(' ');


### PR DESCRIPTION
Saw this pinging all over when profiling the examples. May as well not sacrifice performance here.